### PR TITLE
 Set require app extension api only to YES

### DIFF
--- a/AvatarImageView.xcodeproj/project.pbxproj
+++ b/AvatarImageView.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		2A0C2B441D5BAA98008027CA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -416,6 +417,7 @@
 		2A0C2B451D5BAA98008027CA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;

--- a/AvatarImageView/ColorCache.swift
+++ b/AvatarImageView/ColorCache.swift
@@ -13,13 +13,12 @@ final class ColorCache<ValueType: AnyObject> {
     private let cache = NSCache<NSNumber, ValueType>()
     
     lazy var notificationCenter = NotificationCenter.default
-    lazy var application = UIApplication.shared
     
     init() {
         notificationCenter.addObserver(self,
                                        selector: #selector(clear),
                                        name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning,
-                                       object: application)
+                                       object: nil)
     }
     
     deinit {


### PR DESCRIPTION
Set this to YES so that the AvatarImageView can be used in an app extension.
Tested that the memory warning still gets fired even if object in the Notification handler is nil.

Relevant documentation: https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html